### PR TITLE
イベントごとの準備TODO機能を追加

### DIFF
--- a/db/create_memory_tasks.sql
+++ b/db/create_memory_tasks.sql
@@ -1,0 +1,18 @@
+-- 準備TODOテーブル memory_tasks
+-- 稼働中DBへ手動で1回適用する（追加DDLなのでデータは消えない）:
+--   ローカル(ホスト)MySQL: mysql -u root -p oshikatu < db/create_memory_tasks.sql
+--   Docker MySQL          : docker exec -i oshikatu_db mysql -u root -p oshikatu < db/create_memory_tasks.sql
+-- 1タスク=1行の縦持ち。memory 削除時は ON DELETE CASCADE で連動削除する。
+
+CREATE TABLE IF NOT EXISTS `memory_tasks` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `memory_id` int NOT NULL,
+  `task_name` varchar(255) NOT NULL,
+  `is_completed` tinyint(1) NOT NULL DEFAULT 0,
+  `due_date` date DEFAULT NULL,
+  `created_at` datetime DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `memory_id` (`memory_id`),
+  CONSTRAINT `memory_tasks_ibfk_1`
+    FOREIGN KEY (`memory_id`) REFERENCES `memories` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -815,47 +815,18 @@ label {
    準備TODO（モーダル内）
    ========================================================= */
 #task-section {
-  margin-top: 18px;
-  padding-top: 16px;
+  margin: 34px 0;
+  padding-top: 22px;
   border-top: 1px solid var(--line);
 }
 
 #task-head {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 10px;
 }
 
 #task-head label {
   margin: 0;
-}
-
-#task-progress-pill {
-  flex-shrink: 0;
-  font-family: var(--font-round);
-  font-weight: 700;
-  font-size: 11px;
-  color: var(--coral-deep);
-  background: #F7E3DC;
-  border-radius: 20px;
-  padding: 3px 12px;
-}
-
-#task-progress-track {
-  height: 6px;
-  background: var(--ivory-deep);
-  border-radius: 6px;
-  overflow: hidden;
-  margin: 10px 0 14px;
-}
-
-#task-progress-bar {
-  height: 100%;
-  width: 0%;
-  border-radius: 6px;
-  background: linear-gradient(135deg, var(--coral), var(--coral-deep));
-  transition: width .25s ease;
 }
 
 /* 入力行：テキスト入力＋追加ボタンを横並び（費用入力行に合わせる） */
@@ -863,6 +834,7 @@ label {
   display: flex;
   align-items: center;
   gap: 8px;
+  margin-top: 12px;
 }
 
 #task-input-row #task-name {
@@ -935,24 +907,28 @@ label {
   color: var(--ink-faint);
 }
 
-/* 期限チップ：透明な date input を重ねてネイティブ選択を開く */
+/* 期限チップ：透明な date input を全面に重ねてネイティブ選択を開く */
 .task-due-wrap {
   position: relative;
   display: inline-flex;
   align-items: center;
   gap: 4px;
   flex-shrink: 0;
+  cursor: pointer;
 }
 
 .task-due-chip {
+  display: inline-flex;
+  align-items: center;
+  min-height: 32px;
   font-family: var(--font-round);
   font-weight: 500;
-  font-size: 11px;
+  font-size: 12px;
   color: var(--ink-soft);
   background: var(--ivory);
   border: 1px solid var(--line);
   border-radius: 20px;
-  padding: 4px 10px;
+  padding: 4px 12px;
   white-space: nowrap;
 }
 
@@ -968,16 +944,19 @@ label {
   border-color: var(--coral);
 }
 
+/* 透明 date input をチップ全面に重ねる。クリックは wrap 側で拾って showPicker するため
+   自身はクリックを奪わない（pointer-events: none） */
 .task-due-input {
   position: absolute;
   inset: 0;
   opacity: 0;
   width: 100%;
   height: 100%;
+  min-height: 32px;
   border: none;
   padding: 0;
   margin: 0;
-  cursor: pointer;
+  pointer-events: none;
 }
 
 #modal #task-section .task-due-clear {
@@ -998,15 +977,6 @@ label {
   background: transparent;
   font-size: 15px;
   line-height: 1;
-}
-
-#task-empty {
-  text-align: center;
-  font-family: var(--font-round);
-  font-size: 13px;
-  color: var(--ink-soft);
-  padding: 18px 12px;
-  margin: 10px 0 0;
 }
 
 #task-completed-wrap {

--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -811,6 +811,221 @@ label {
   border: 1px solid var(--line) !important;
 }
 
+/* =========================================================
+   準備TODO（モーダル内）
+   ========================================================= */
+#task-section {
+  margin-top: 18px;
+  padding-top: 16px;
+  border-top: 1px solid var(--line);
+}
+
+#task-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+#task-head label {
+  margin: 0;
+}
+
+#task-progress-pill {
+  flex-shrink: 0;
+  font-family: var(--font-round);
+  font-weight: 700;
+  font-size: 11px;
+  color: var(--coral-deep);
+  background: #F7E3DC;
+  border-radius: 20px;
+  padding: 3px 12px;
+}
+
+#task-progress-track {
+  height: 6px;
+  background: var(--ivory-deep);
+  border-radius: 6px;
+  overflow: hidden;
+  margin: 10px 0 14px;
+}
+
+#task-progress-bar {
+  height: 100%;
+  width: 0%;
+  border-radius: 6px;
+  background: linear-gradient(135deg, var(--coral), var(--coral-deep));
+  transition: width .25s ease;
+}
+
+/* 入力行：テキスト入力＋追加ボタンを横並び（費用入力行に合わせる） */
+#task-input-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+#task-input-row #task-name {
+  flex: 1;
+  min-width: 0;
+}
+
+#modal #task-section button {
+  margin: 0;
+  padding: 0;
+  border-radius: 12px;
+}
+
+#modal #task-section #task-add {
+  flex-shrink: 0;
+  padding: 11px 14px;
+  background: var(--ivory-deep);
+  color: var(--ink);
+}
+
+#task-list,
+#task-completed-list {
+  list-style: none;
+  margin: 12px 0 0;
+  padding: 0;
+}
+
+.task-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-soft);
+  margin-bottom: 8px;
+}
+
+#modal #task-section .task-check {
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 2px solid var(--line) !important;
+  background: var(--card);
+  color: #fff;
+  font-size: 13px;
+  line-height: 1;
+  display: grid;
+  place-items: center;
+}
+
+#modal #task-section .task-item.is-completed .task-check {
+  background: var(--coral);
+  border-color: var(--coral) !important;
+}
+
+.task-name-text {
+  flex: 1;
+  min-width: 0;
+  font-family: var(--font-round);
+  font-size: 14px;
+  color: var(--ink);
+  word-break: break-word;
+}
+
+.task-item.is-completed .task-name-text {
+  text-decoration: line-through;
+  color: var(--ink-faint);
+}
+
+/* 期限チップ：透明な date input を重ねてネイティブ選択を開く */
+.task-due-wrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.task-due-chip {
+  font-family: var(--font-round);
+  font-weight: 500;
+  font-size: 11px;
+  color: var(--ink-soft);
+  background: var(--ivory);
+  border: 1px solid var(--line);
+  border-radius: 20px;
+  padding: 4px 10px;
+  white-space: nowrap;
+}
+
+.task-due-chip.is-empty {
+  color: var(--ink-faint);
+  background: transparent;
+  border-style: dashed;
+}
+
+.task-due-chip.is-overdue {
+  color: var(--coral-deep);
+  background: #FBEFEA;
+  border-color: var(--coral);
+}
+
+.task-due-input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+#modal #task-section .task-due-clear {
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--ivory-deep);
+  color: var(--ink-soft);
+  font-size: 12px;
+  line-height: 1;
+  display: grid;
+  place-items: center;
+}
+
+#modal #task-section .task-delete {
+  flex-shrink: 0;
+  background: transparent;
+  font-size: 15px;
+  line-height: 1;
+}
+
+#task-empty {
+  text-align: center;
+  font-family: var(--font-round);
+  font-size: 13px;
+  color: var(--ink-soft);
+  padding: 18px 12px;
+  margin: 10px 0 0;
+}
+
+#task-completed-wrap {
+  display: none;
+}
+
+#task-completed-divider {
+  font-family: var(--font-round);
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--ink-faint);
+  margin: 14px 0 8px;
+}
+
+.task-item.is-completed {
+  background: var(--ivory);
+  box-shadow: none;
+}
+
 /* ---------- レスポンシブ ---------- */
 @media (max-width: 380px) {
   .tab {

--- a/src/controllers/memoryController.ts
+++ b/src/controllers/memoryController.ts
@@ -81,7 +81,7 @@ const parseTasks = (raw: unknown): MemoryTaskInput[] => {
     }
     // タスクは重複可のため件数が無制限になりやすい。大量INSERT防止に上限を設ける
     if (parsed.length > MAX_TASKS) {
-        throw new Error("INVALID_TASK_FORMAT");
+        throw new Error("INVALID_TASK_COUNT");
     }
     const tasks: MemoryTaskInput[] = [];
     for (const item of parsed) {
@@ -152,6 +152,9 @@ const handleTaskValidationError = (error: unknown, res: Response): boolean => {
     switch (error.message) {
         case "INVALID_TASK_FORMAT":
             res.status(400).json({ message: "準備TODOの形式が正しくありません" });
+            return true;
+        case "INVALID_TASK_COUNT":
+            res.status(400).json({ message: "準備TODOは100件までです" });
             return true;
         case "INVALID_TASK_NAME":
             res.status(400).json({ message: "準備TODOは1〜255文字で入力してください" });

--- a/src/controllers/memoryController.ts
+++ b/src/controllers/memoryController.ts
@@ -1,9 +1,13 @@
 import { Request, Response } from "express"
 import memoryService from "../services/memoryService";
 import { isValidCostCategory } from "../config/costCategories";
-import { MemoryCost } from "../models/memoryModel";
+import { MemoryCost, MemoryTaskInput } from "../models/memoryModel";
 
 const MAX_COST_AMOUNT = 9999999;
+const MAX_TASK_NAME_LENGTH = 255;
+const MAX_TASKS = 100;
+// due_date は YYYY-MM-DD 形式のみ許可（過去日も可）
+const DUE_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
 // FormData の JSON文字列フィールド costs をパースし、型付き配列に変換・検証する。
 // 不正時は Error(message) を throw し、呼び出し側で 400 に振り分ける。
@@ -50,6 +54,73 @@ const parseCosts = (raw: unknown): MemoryCost[] => {
     return costs;
 };
 
+// 実在する日付か（YYYY-MM-DD 形式は正規表現で確認済みの前提）を検証する
+const isRealDate = (value: string): boolean => {
+    const [year, month, day] = value.split("-").map(Number);
+    const date = new Date(year, month - 1, day);
+    return date.getFullYear() === year && date.getMonth() === month - 1 && date.getDate() === day;
+};
+
+// FormData の JSON文字列フィールド tasks をパースし、型付き配列に変換・検証する（parseCosts と同型）。
+// 不正時は Error(message) を throw し、呼び出し側で 400 に振り分ける。
+const parseTasks = (raw: unknown): MemoryTaskInput[] => {
+    if (raw === undefined || raw === null || raw === "") {
+        return [];
+    }
+    if (typeof raw !== "string") {
+        throw new Error("INVALID_TASK_FORMAT");
+    }
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(raw);
+    } catch {
+        throw new Error("INVALID_TASK_FORMAT");
+    }
+    if (!Array.isArray(parsed)) {
+        throw new Error("INVALID_TASK_FORMAT");
+    }
+    // タスクは重複可のため件数が無制限になりやすい。大量INSERT防止に上限を設ける
+    if (parsed.length > MAX_TASKS) {
+        throw new Error("INVALID_TASK_FORMAT");
+    }
+    const tasks: MemoryTaskInput[] = [];
+    for (const item of parsed) {
+        if (typeof item !== "object" || item === null) {
+            throw new Error("INVALID_TASK_FORMAT");
+        }
+        const rawName = (item as { task_name?: unknown }).task_name;
+        const rawCompleted = (item as { is_completed?: unknown }).is_completed;
+        const rawDueDate = (item as { due_date?: unknown }).due_date;
+        if (typeof rawName !== "string") {
+            throw new Error("INVALID_TASK_NAME");
+        }
+        const taskName = rawName.trim();
+        if (taskName.length < 1 || taskName.length > MAX_TASK_NAME_LENGTH) {
+            throw new Error("INVALID_TASK_NAME");
+        }
+        // is_completed は真偽値／0／1 を許容し 0|1 へ正規化する
+        let isCompleted: number;
+        if (rawCompleted === true || rawCompleted === 1) {
+            isCompleted = 1;
+        } else if (rawCompleted === false || rawCompleted === 0 || rawCompleted === undefined || rawCompleted === null) {
+            isCompleted = 0;
+        } else {
+            throw new Error("INVALID_TASK_COMPLETED");
+        }
+        // due_date は空・null は未設定、指定時は YYYY-MM-DD 形式かつ実在日
+        let dueDate: string | null;
+        if (rawDueDate === undefined || rawDueDate === null || rawDueDate === "") {
+            dueDate = null;
+        } else if (typeof rawDueDate === "string" && DUE_DATE_PATTERN.test(rawDueDate) && isRealDate(rawDueDate)) {
+            dueDate = rawDueDate;
+        } else {
+            throw new Error("INVALID_TASK_DUE_DATE");
+        }
+        tasks.push({ task_name: taskName, is_completed: isCompleted, due_date: dueDate });
+    }
+    return tasks;
+};
+
 // 費用バリデーションのエラーを日本語メッセージ付き 400 レスポンスへ変換する。該当しなければ false。
 const handleCostValidationError = (error: unknown, res: Response): boolean => {
     if (!(error instanceof Error)) {
@@ -73,15 +144,40 @@ const handleCostValidationError = (error: unknown, res: Response): boolean => {
     }
 };
 
+// 準備TODOバリデーションのエラーを日本語メッセージ付き 400 レスポンスへ変換する。該当しなければ false。
+const handleTaskValidationError = (error: unknown, res: Response): boolean => {
+    if (!(error instanceof Error)) {
+        return false;
+    }
+    switch (error.message) {
+        case "INVALID_TASK_FORMAT":
+            res.status(400).json({ message: "準備TODOの形式が正しくありません" });
+            return true;
+        case "INVALID_TASK_NAME":
+            res.status(400).json({ message: "準備TODOは1〜255文字で入力してください" });
+            return true;
+        case "INVALID_TASK_COMPLETED":
+            res.status(400).json({ message: "準備TODOの完了状態が正しくありません" });
+            return true;
+        case "INVALID_TASK_DUE_DATE":
+            res.status(400).json({ message: "準備TODOの期限が正しくありません" });
+            return true;
+        default:
+            return false;
+    }
+};
+
 export const registerMemoryController = async (req: Request, res: Response) => {
     try {
         const costs = parseCosts(req.body.costs);
+        const tasks = parseTasks(req.body.tasks);
         const result=await memoryService.register({
             memory: req.body.memory,
             title: req.body.title,
             date: req.body.date,
             category: req.body.category,
             costs: costs,
+            tasks: tasks,
             files: req.files as Express.Multer.File[]
         })
 
@@ -90,6 +186,9 @@ export const registerMemoryController = async (req: Request, res: Response) => {
     } catch (error) {
         console.error(error);
         if (handleCostValidationError(error, res)) {
+            return;
+        }
+        if (handleTaskValidationError(error, res)) {
             return;
         }
          if (error instanceof Error) {
@@ -132,11 +231,13 @@ export const fetchMemoryController = async (_req: Request, res: Response) => {
 export const updateMemoryController = async (req: Request, res: Response) => {
     try {
     const costs = parseCosts(req.body.costs);
+    const tasks = parseTasks(req.body.tasks);
     const result= await memoryService.update({
         id: req.body.id,
         memory: req.body.memory,
         date: req.body.date,
         costs: costs,
+        tasks: tasks,
         category: req.body.category,
         title: req.body.title,
         files: req.files as Express.Multer.File[]|undefined
@@ -145,6 +246,9 @@ export const updateMemoryController = async (req: Request, res: Response) => {
 } catch (error) {
     console.error(error);
     if (handleCostValidationError(error, res)) {
+        return;
+    }
+    if (handleTaskValidationError(error, res)) {
         return;
     }
     if (error instanceof Error) {

--- a/src/models/memoryModel.ts
+++ b/src/models/memoryModel.ts
@@ -7,6 +7,20 @@ export type MemoryCost = {
   amount: number;
 };
 
+export type MemoryTask = {
+  id: number;
+  task_name: string;
+  is_completed: number;
+  due_date: string | null;
+};
+
+// 登録・更新時の入力（idはDB採番のため持たない）
+export type MemoryTaskInput = {
+  task_name: string;
+  is_completed: number;
+  due_date: string | null;
+};
+
 type MemoryWithImages = {
   id: number;
   date: string;
@@ -14,6 +28,7 @@ type MemoryWithImages = {
   memory: string;
   cost: number;
   costs: MemoryCost[];
+  tasks: MemoryTask[];
   category:string;
   color:string;
   imageUrl: string[];
@@ -34,7 +49,7 @@ const categoryColorMap: Record<string, string> = {
   activity: "#9D4EDD"
 };
 
-export const registerMemoryModel=async(memory:string,title:string,category:string,date:string,costs:MemoryCost[],imageUrl:string[]):Promise<void>=>{
+export const registerMemoryModel=async(memory:string,title:string,category:string,date:string,costs:MemoryCost[],tasks:MemoryTaskInput[],imageUrl:string[]):Promise<void>=>{
 const conn=await connection.getConnection()
 try{
     await conn.beginTransaction();
@@ -47,6 +62,10 @@ try{
     }
     for(const c of costs){
         await conn.execute('insert into memory_costs (memory_id,category,amount) values (?,?,?)',[memoryId,c.category,c.amount])
+    }
+    // 準備TODOも費用と同じく明細一括INSERT
+    for(const t of tasks){
+        await conn.execute('insert into memory_tasks (memory_id,task_name,is_completed,due_date) values (?,?,?,?)',[memoryId,t.task_name,t.is_completed,t.due_date])
     }
     await conn.commit();
 }catch(error){
@@ -95,6 +114,7 @@ export const fetchMemoryModel=async():Promise<MemoryWithImages[]>=>{
         category:row.category,
         cost: row.cost,
         costs: [],
+        tasks: [],
         imageUrl: [],
         color:categoryColorMap[row.category]
       });
@@ -111,11 +131,23 @@ export const fetchMemoryModel=async():Promise<MemoryWithImages[]>=>{
     memoryMap.get(cost.memory_id)?.costs.push({ category: cost.category, amount: cost.amount });
   }
 
+  // 準備TODOも別クエリで取得して memory_id で紐付ける（画像・費用との直積を避ける）
+  // due_date は DATE 型を YYYY-MM-DD 文字列で受け取り（NULL可）、未完了→完了・id昇順で並べる
+  const [taskRows]=await connection.execute<RowDataPacket[]>("select memory_id,id,task_name,is_completed,date_format(due_date,'%Y-%m-%d') as due_date from memory_tasks order by is_completed asc, id asc")
+  for (const task of taskRows) {
+    memoryMap.get(task.memory_id)?.tasks.push({
+      id: task.id,
+      task_name: task.task_name,
+      is_completed: task.is_completed,
+      due_date: task.due_date
+    });
+  }
+
   return Array.from(memoryMap.values());
 
 }
 
-export const updateMemoryModel=async(memory:string,title:string,date:string,costs:MemoryCost[],category:string,imageUrl:string[],id:string):Promise<boolean>=>{
+export const updateMemoryModel=async(memory:string,title:string,date:string,costs:MemoryCost[],tasks:MemoryTaskInput[],category:string,imageUrl:string[],id:string):Promise<boolean>=>{
 const conn=await connection.getConnection();
 try{
 await conn.beginTransaction();
@@ -130,6 +162,11 @@ await conn.execute('INSERT INTO memory_images (memory_id,image_path) values (?,?
 await conn.execute('DELETE FROM memory_costs where memory_id=?',[id])
 for(const c of costs){
 await conn.execute('INSERT INTO memory_costs (memory_id,category,amount) values (?,?,?)',[id,c.category,c.amount])
+}
+// 準備TODOも全削除→再挿入（費用と同型）
+await conn.execute('DELETE FROM memory_tasks where memory_id=?',[id])
+for(const t of tasks){
+await conn.execute('INSERT INTO memory_tasks (memory_id,task_name,is_completed,due_date) values (?,?,?,?)',[id,t.task_name,t.is_completed,t.due_date])
 }
 await conn.commit();
 return true;

--- a/src/services/memoryService.ts
+++ b/src/services/memoryService.ts
@@ -1,4 +1,4 @@
-import { registerMemoryModel, fetchMemoryModel, updateMemoryModel, deleteMemoryModel, MemoryCost } from "../models/memoryModel";
+import { registerMemoryModel, fetchMemoryModel, updateMemoryModel, deleteMemoryModel, MemoryCost, MemoryTaskInput } from "../models/memoryModel";
 import s3 from "../config/s3"
 import { v4 as uuidv4 } from 'uuid'
 import path from 'path'
@@ -19,6 +19,7 @@ type registerMemoryDto = {
     date: string,
     category: string,
     costs: MemoryCost[],
+    tasks: MemoryTaskInput[],
     files: Express.Multer.File[]
 }
 type updateMemoryDto = {
@@ -28,6 +29,7 @@ type updateMemoryDto = {
     date: string,
     category: string,
     costs: MemoryCost[],
+    tasks: MemoryTaskInput[],
     files: Express.Multer.File[] | undefined
 }
 
@@ -59,7 +61,7 @@ class MemoryService {
             }
         }
         try {
-            await registerMemoryModel(data.memory, data.title, data.category, data.date, data.costs, imageUrl)
+            await registerMemoryModel(data.memory, data.title, data.category, data.date, data.costs, data.tasks, imageUrl)
         } catch (error) {
             //DB更新失敗時はアップロード済みS3ファイルをロールバック
             await Promise.all(deleteUrl.map(key =>
@@ -85,6 +87,7 @@ class MemoryService {
             extendedProps: {
                 id: memory.id.toString(),
                 costs: memory.costs,
+                tasks: memory.tasks,
                 memory: memory.memory,
                 imageUrl: memory.imageUrl,
                 category: memory.category
@@ -124,7 +127,7 @@ class MemoryService {
         //DB更新
         let updateResult: boolean
         try {
-            updateResult = await updateMemoryModel(data.memory, data.title, data.date, data.costs, data.category, imageUrl, data.id)
+            updateResult = await updateMemoryModel(data.memory, data.title, data.date, data.costs, data.tasks, data.category, imageUrl, data.id)
         } catch (error) {
             //DB更新が例外で失敗した場合も新規アップロード済みS3ファイルをロールバック
             await Promise.all(deleteUrl.map(key =>

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -153,6 +153,8 @@
       // モーダルで編集中の準備TODO（費用と同じくクライアント保持→保存時に一括送信）
       let tasks = [];
       const MAX_TASK_NAME_LENGTH = 255;
+      // サーバの MAX_TASKS と一致させる（超過保存を保存前に弾く）
+      const MAX_TASKS = 100;
 
       // ローカル日付を YYYY-MM-DD 文字列で取得（期限切れ判定の基準）
       function todayStr() {
@@ -280,6 +282,10 @@
         const name = input.value.trim();
         if (name === "") {
           alert("準備することを入力してください");
+          return;
+        }
+        if (tasks.length >= MAX_TASKS) {
+          alert("準備TODOは" + MAX_TASKS + "件までです");
           return;
         }
         if (name.length > MAX_TASK_NAME_LENGTH) {

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -30,6 +30,25 @@
     </div>
     <ul id="cost-list"></ul>
     <p id="cost-total">合計: 0円</p>
+    <div id="task-section">
+      <div id="task-head">
+        <label>準備TODO</label>
+        <span id="task-progress-pill">準備なし</span>
+      </div>
+      <div id="task-progress-track">
+        <div id="task-progress-bar"></div>
+      </div>
+      <div id="task-input-row">
+        <input type="text" id="task-name" placeholder="準備することを追加（例: チケット発券）">
+        <button type="button" id="task-add">＋追加</button>
+      </div>
+      <ul id="task-list"></ul>
+      <p id="task-empty">🗓️ まだ準備することがありません。上の欄から追加してみましょう。</p>
+      <div id="task-completed-wrap">
+        <p id="task-completed-divider">完了した準備</p>
+        <ul id="task-completed-list"></ul>
+      </div>
+    </div>
     <label for="memory-text">メモ</label><br>
     <textarea id="memory-text" rows="5" cols="30"></textarea><br>
     <div id="preview-img"></div>
@@ -131,6 +150,147 @@
         renderCosts();
       }
 
+      // モーダルで編集中の準備TODO（費用と同じくクライアント保持→保存時に一括送信）
+      let tasks = [];
+      const MAX_TASK_NAME_LENGTH = 255;
+
+      // ローカル日付を YYYY-MM-DD 文字列で取得（期限切れ判定の基準）
+      function todayStr() {
+        const now = new Date();
+        const y = now.getFullYear();
+        const m = String(now.getMonth() + 1).padStart(2, "0");
+        const d = String(now.getDate()).padStart(2, "0");
+        return `${y}-${m}-${d}`;
+      }
+      // YYYY-MM-DD を M/D 表示へ整形
+      function formatDueLabel(due) {
+        const [, m, d] = due.split("-");
+        return `${Number(m)}/${Number(d)}`;
+      }
+
+      // 期限チップを生成する（未設定は破線「＋期限」、設定時は日付＋クリア）
+      function createDueChip(task, index) {
+        const wrap = document.createElement("span");
+        wrap.className = "task-due-wrap";
+        const chip = document.createElement("span");
+        chip.className = "task-due-chip";
+        // 期限切れ＋未完了のみ赤（完了済みは赤にしない）
+        if (task.due_date) {
+          chip.textContent = `📅 ${formatDueLabel(task.due_date)}`;
+          if (!task.is_completed && task.due_date < todayStr()) {
+            chip.classList.add("is-overdue");
+          }
+        } else {
+          chip.classList.add("is-empty");
+          chip.textContent = "＋期限";
+        }
+        // チップに重ねた透明な date input でネイティブの日付選択を開く
+        const dateInput = document.createElement("input");
+        dateInput.type = "date";
+        dateInput.className = "task-due-input";
+        if (task.due_date) dateInput.value = task.due_date;
+        dateInput.addEventListener("change", () => {
+          tasks[index].due_date = dateInput.value ? dateInput.value : null;
+          renderTasks();
+        });
+        wrap.appendChild(chip);
+        wrap.appendChild(dateInput);
+        if (task.due_date) {
+          const clearBtn = document.createElement("button");
+          clearBtn.type = "button";
+          clearBtn.className = "task-due-clear";
+          clearBtn.textContent = "×";
+          clearBtn.addEventListener("click", () => {
+            tasks[index].due_date = null;
+            renderTasks();
+          });
+          wrap.appendChild(clearBtn);
+        }
+        return wrap;
+      }
+
+      // 1タスクの行を生成する
+      function createTaskItem(task, index) {
+        const li = document.createElement("li");
+        li.className = "task-item";
+        if (task.is_completed) li.classList.add("is-completed");
+        const check = document.createElement("button");
+        check.type = "button";
+        check.className = "task-check";
+        check.setAttribute("aria-label", task.is_completed ? "未完了に戻す" : "完了にする");
+        check.textContent = task.is_completed ? "✓" : "";
+        check.addEventListener("click", () => {
+          tasks[index].is_completed = tasks[index].is_completed ? 0 : 1;
+          renderTasks();
+        });
+        const name = document.createElement("span");
+        name.className = "task-name-text";
+        name.textContent = task.task_name;
+        const del = document.createElement("button");
+        del.type = "button";
+        del.className = "task-delete";
+        del.textContent = "🗑️";
+        del.addEventListener("click", () => {
+          tasks.splice(index, 1);
+          renderTasks();
+        });
+        li.appendChild(check);
+        li.appendChild(name);
+        li.appendChild(createDueChip(task, index));
+        li.appendChild(del);
+        return li;
+      }
+
+      // 進捗ピル・バー・一覧を再描画する（未完了は上、完了は区切りの下）
+      function renderTasks() {
+        const list = document.getElementById("task-list");
+        const completedList = document.getElementById("task-completed-list");
+        const empty = document.getElementById("task-empty");
+        const completedWrap = document.getElementById("task-completed-wrap");
+        list.innerHTML = "";
+        completedList.innerHTML = "";
+        let completedCount = 0;
+        tasks.forEach((task, index) => {
+          const item = createTaskItem(task, index);
+          if (task.is_completed) {
+            completedCount++;
+            completedList.appendChild(item);
+          } else {
+            list.appendChild(item);
+          }
+        });
+        const total = tasks.length;
+        const pill = document.getElementById("task-progress-pill");
+        const bar = document.getElementById("task-progress-bar");
+        if (total === 0) {
+          pill.textContent = "準備なし";
+          bar.style.width = "0%";
+          empty.style.display = "block";
+        } else {
+          pill.textContent = `${completedCount} / ${total} 完了`;
+          bar.style.width = `${Math.round((completedCount / total) * 100)}%`;
+          empty.style.display = "none";
+        }
+        completedWrap.style.display = completedCount > 0 ? "block" : "none";
+      }
+
+      // 準備TODOを追加する（名前のみ、trimして1〜255文字）
+      function addTask() {
+        const input = document.getElementById("task-name");
+        const name = input.value.trim();
+        if (name === "") {
+          alert("準備することを入力してください");
+          return;
+        }
+        if (name.length > MAX_TASK_NAME_LENGTH) {
+          alert("準備TODOは" + MAX_TASK_NAME_LENGTH + "文字以内で入力してください");
+          return;
+        }
+        tasks.push({ task_name: name, is_completed: 0, due_date: null });
+        input.value = "";
+        renderTasks();
+      }
+
       const calendarEl = document.getElementById("calendar");
       const calendar = new FullCalendar.Calendar(calendarEl, {
         initialView: 'dayGridMonth',
@@ -153,6 +313,8 @@
           event = null
           costs = [];
           renderCosts();
+          tasks = [];
+          renderTasks();
           document.getElementById("save").style.display = "";
           document.getElementById("update").style.display = "none";
           document.getElementById("selected-date").textContent = info.dateStr;
@@ -167,6 +329,13 @@
           // 登録済みの費用明細を復元表示
           costs = (event.extendedProps.costs || []).map(c => ({ category: c.category, amount: c.amount }));
           renderCosts();
+          // 登録済みの準備TODOを復元表示（ローカル配列で保持）
+          tasks = (event.extendedProps.tasks || []).map(t => ({
+            task_name: t.task_name,
+            is_completed: t.is_completed ? 1 : 0,
+            due_date: t.due_date || null
+          }));
+          renderTasks();
           if (!event.title) {
             document.getElementById("delete").style.display = "none"
             document.getElementById("update").style.display = "none"
@@ -187,6 +356,14 @@
       saveButton.addEventListener("click", clickButton)
       updateButton.addEventListener("click", clickButton)
       document.getElementById("cost-add").addEventListener("click", addCost)
+      document.getElementById("task-add").addEventListener("click", addTask)
+      // Enterキーでも準備TODOを追加（改行送信を抑止）
+      document.getElementById("task-name").addEventListener("keydown", (e) => {
+        if (e.key === "Enter") {
+          e.preventDefault();
+          addTask();
+        }
+      })
       async function clickButton() {
         const title = document.getElementById("title").value
         const category = document.getElementById("category").value
@@ -201,6 +378,11 @@
         // 費用の入力欄に未追加の金額が残っている場合は、押し忘れとみなして保存を止める
         if (document.getElementById("cost-amount").value.trim() !== "") {
           alert("追加していない費用があります。「＋費用を追加」を押すか、金額の入力を消してから保存してください")
+          return
+        }
+        // 準備TODOの入力欄に未追加の名前が残っている場合も同様に止める
+        if (document.getElementById("task-name").value.trim() !== "") {
+          alert("追加していない準備TODOがあります。「＋追加」を押すか、入力を消してから保存してください")
           return
         }
         const save_confirm = confirm("この内容で保存してよろしいですか？元データがある場合、上書きされます。");
@@ -219,6 +401,7 @@
           formData.append("memory", memory)
           formData.append("category", category)
           formData.append("costs", JSON.stringify(costs))
+          formData.append("tasks", JSON.stringify(tasks))
           if (files && files.length > 0) {
             for (let i = 0; i < files.length; i++) {
               formData.append("files", files[i])
@@ -256,6 +439,7 @@
               existingEvent.setExtendedProp("memory", memory);
               existingEvent.setExtendedProp("category", category)
               existingEvent.setExtendedProp("costs", costs)
+              existingEvent.setExtendedProp("tasks", tasks)
               //以下は要調整
               existingEvent.setProp("color", categoryColorMap[category] || "#CCCCCC")
               existingEvent.setExtendedProp("imageUrl", result.imageUrl);
@@ -270,6 +454,7 @@
                   memory: memory,
                   category: category,
                   costs: costs,
+                  tasks: tasks,
                   imageUrl: result.imageUrl
                 }
               })
@@ -308,6 +493,9 @@
         document.getElementById("cost-category").value = "";
         document.getElementById("cost-amount").value = "";
         renderCosts();
+        tasks = [];
+        document.getElementById("task-name").value = "";
+        renderTasks();
 
       }
       // 複数画像を表示する関数を追加

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -33,17 +33,12 @@
     <div id="task-section">
       <div id="task-head">
         <label>準備TODO</label>
-        <span id="task-progress-pill">準備なし</span>
-      </div>
-      <div id="task-progress-track">
-        <div id="task-progress-bar"></div>
       </div>
       <div id="task-input-row">
         <input type="text" id="task-name" placeholder="準備することを追加（例: チケット発券）">
         <button type="button" id="task-add">＋追加</button>
       </div>
       <ul id="task-list"></ul>
-      <p id="task-empty">🗓️ まだ準備することがありません。上の欄から追加してみましょう。</p>
       <div id="task-completed-wrap">
         <p id="task-completed-divider">完了した準備</p>
         <ul id="task-completed-list"></ul>
@@ -195,6 +190,18 @@
           tasks[index].due_date = dateInput.value ? dateInput.value : null;
           renderTasks();
         });
+        // タップで確実にカレンダーを開く（未対応環境はフォーカスへフォールバック）
+        wrap.addEventListener("click", () => {
+          if (typeof dateInput.showPicker === "function") {
+            try {
+              dateInput.showPicker();
+            } catch (e) {
+              dateInput.focus();
+            }
+          } else {
+            dateInput.focus();
+          }
+        });
         wrap.appendChild(chip);
         wrap.appendChild(dateInput);
         if (task.due_date) {
@@ -202,7 +209,9 @@
           clearBtn.type = "button";
           clearBtn.className = "task-due-clear";
           clearBtn.textContent = "×";
-          clearBtn.addEventListener("click", () => {
+          clearBtn.addEventListener("click", (e) => {
+            // wrap のクリック（ピッカー起動）を誘発させない
+            e.stopPropagation();
             tasks[index].due_date = null;
             renderTasks();
           });
@@ -243,11 +252,10 @@
         return li;
       }
 
-      // 進捗ピル・バー・一覧を再描画する（未完了は上、完了は区切りの下）
+      // タスク一覧を再描画する（未完了は上、完了は区切りの下）
       function renderTasks() {
         const list = document.getElementById("task-list");
         const completedList = document.getElementById("task-completed-list");
-        const empty = document.getElementById("task-empty");
         const completedWrap = document.getElementById("task-completed-wrap");
         list.innerHTML = "";
         completedList.innerHTML = "";
@@ -261,18 +269,6 @@
             list.appendChild(item);
           }
         });
-        const total = tasks.length;
-        const pill = document.getElementById("task-progress-pill");
-        const bar = document.getElementById("task-progress-bar");
-        if (total === 0) {
-          pill.textContent = "準備なし";
-          bar.style.width = "0%";
-          empty.style.display = "block";
-        } else {
-          pill.textContent = `${completedCount} / ${total} 完了`;
-          bar.style.width = `${Math.round((completedCount / total) * 100)}%`;
-          empty.style.display = "none";
-        }
         completedWrap.style.display = completedCount > 0 ? "block" : "none";
       }
 


### PR DESCRIPTION
## 概要
推し活イベント（memories）ごとに「準備TODO」リストを持てる新機能。新幹線予約・ホテル予約など当日までにやることを、チェックで完了管理できる。

## 主な変更
- **新テーブル `memory_tasks`**（`db/create_memory_tasks.sql`）: memory_id FK（ON DELETE CASCADE）/ task_name / is_completed / due_date / created_at。稼働中DBへは手動適用（create_memory_costs.sql と同じ運用）。
- **保存方式は費用(costs)と同型**: モーダル内でクライアント配列に保持し、追加・完了チェック・期限設定/クリア・削除はローカルで即時反映（未保存）。永続化は登録/更新ボタンで FormData 一括送信し、register/update の既存トランザクション内で挿入（update は全削除→再挿入）。**操作ごとにDBを叩かない**。
- **読み取り**: fetchMemoryModel でタスクを別クエリ取得し memory_id で紐付け（直積JOIN回避）。`ORDER BY is_completed ASC, id ASC`。
- **検証**: parseTasks（task_name trim後1〜255・件数上限100・is_completed 0/1・due_date YYYY-MM-DD or NULL）。不正時は日本語400。
- **UI**: モーダル内、費用の下・メモの上に配置。完了数ピル（0件は「準備なし」）＋コーラル進捗バー、追加行（テキスト＋＋追加、Enter可）、丸チェック、期限チップ（input[type=date]、未設定は破線「＋期限」）、期限切れ＋未完了は赤、完了は「完了した準備」区切り下に取り消し線＋グレーアウト、0件時は空メッセージ。既存のくすみパステル×アイボリーのデザインを踏襲。

## 対象外
ホームへの未完了タスク表示 / ドラッグ並び替え / テンプレート / completed_at 保存。

## 確認方法
1. `db/create_memory_tasks.sql` をDBへ適用（例: `docker exec -i oshikatu_db mysql -u root -p oshikatu < db/create_memory_tasks.sql`）
2. `npm run dev` → カレンダーの日付をクリックしてモーダルを開く → 準備TODOを追加/完了/期限設定/削除 → 登録
3. 再度開いて反映を確認。期限を過去日にして未完了なら赤チップ、完了で下段へ移動、進捗バーの伸縮を確認
4. `npm run build` 成功済み

## 設計メモ
- タスクは状態(is_completed)を持つが、保存単位をイベント全体に揃えることで UX とトランザクション整合を優先。個別APIを増やさず既存 costs パターンを再利用（変更箇所最小・重複回避）。
- 型は読み取り用 `MemoryTask`（id有）と入力用 `MemoryTaskInput`（id無）を分離し any 不使用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)