### PR TITLE
集計画面に月ごとの活動回数・費用の棒グラフを追加

### DIFF
--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -351,34 +351,84 @@ body {
    集計（Chart.js）
    ========================================================= */
 
-#analyze>label,
-#analyze label {
+/* ゾーン：年で見るエリア／月で見るエリアを見出し＋うっすら背景で仕切る */
+.zone {
+  border-radius: var(--radius);
+  padding: 18px 16px 16px;
+  border: 1px solid var(--line);
+}
+
+.zone.year {
+  background: rgba(169, 192, 214, .12);
+  border-color: rgba(169, 192, 214, .35);
+}
+
+.zone.month {
+  margin-top: 26px;
+  background: rgba(227, 160, 141, .10);
+  border-color: rgba(227, 160, 141, .32);
+}
+
+.zone-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.zone-ic {
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  display: grid;
+  place-items: center;
+  font-size: 20px;
+  flex-shrink: 0;
+}
+
+.zone-ic.blue {
+  background: #DCE6EF;
+}
+
+.zone-ic.coral {
+  background: #F7E3DC;
+}
+
+.zone-head-text {
+  min-width: 0;
+}
+
+.zone-title {
   font-family: var(--font-round);
-  font-size: 15px;
+  font-size: 16px;
   font-weight: 700;
   color: var(--ink);
-  text-decoration: none;
-  display: block;
-  flex-basis: 100%;
-  margin: 0 4px 10px;
 }
 
-#analyze {
-  margin-top: 34px;
-  margin-bottom: 8px;
+.zone-sub {
+  font-size: 12px;
+  color: var(--ink-soft);
+  margin-top: 2px;
+}
+
+.zone-select {
   display: flex;
-  flex-wrap: wrap;
-  align-items: flex-end;
+  align-items: center;
   gap: 10px;
+  margin-bottom: 14px;
 }
 
-#analyze>div {
+.zone-select label {
+  font-family: var(--font-round);
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--ink);
+  flex-shrink: 0;
+}
+
+.zone-select select {
   flex: 1;
   min-width: 120px;
-}
-
-#analyze select {
-  width: 100%;
   background: var(--card);
   border: 1px solid var(--line);
   border-radius: var(--radius-sm);
@@ -398,7 +448,8 @@ body {
 #yearly-summary {
   margin-bottom: 22px;
   padding: 4px 16px 16px;
-  background: rgba(195, 175, 212, .1);
+  /* 年ゾーン（青み）の上に乗るので、淡ラベンダーだと色が重なって濁る。白系カードで軽く浮かせる */
+  background: rgba(255, 255, 255, .55);
   border-radius: var(--radius);
 }
 

--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -584,13 +584,19 @@ body {
   color: var(--coral-deep);
 }
 
-#chart-message:not(:empty) {
+#chart-message:not(:empty),
+#monthly-message:not(:empty) {
   text-align: center;
   padding: 48px 16px;
   font-family: var(--font-round);
   font-weight: 700;
   font-size: 15px;
   color: var(--ink-soft);
+}
+
+/* 空のときは余白を出さない（メッセージ要素が場所を取らないように） */
+#monthly-message {
+  margin: 0;
 }
 
 /* =========================================================

--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -453,12 +453,16 @@ body {
   border-radius: var(--radius);
 }
 
-#yearly-heading {
+#yearly-heading,
+.monthly-heading {
   font-family: var(--font-round);
   font-weight: 700;
   font-size: 15px;
   color: var(--ink);
   text-align: left;
+}
+
+#yearly-heading {
   margin: 18px 4px 12px;
 }
 
@@ -510,13 +514,8 @@ body {
   margin: 26px 4px 12px;
 }
 
-/* 月別棒グラフの見出し。既存の #yearly-heading に準じたトーンで揃える */
+/* 月別棒グラフの見出し。共通スタイルは #yearly-heading とまとめ、余白のみ個別指定 */
 .monthly-heading {
-  font-family: var(--font-round);
-  font-weight: 700;
-  font-size: 15px;
-  color: var(--ink);
-  text-align: left;
   margin: 26px 4px 12px;
 }
 

--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -458,6 +458,16 @@ body {
   margin: 26px 4px 12px;
 }
 
+/* 月別棒グラフの見出し。既存の #yearly-heading に準じたトーンで揃える */
+.monthly-heading {
+  font-family: var(--font-round);
+  font-weight: 700;
+  font-size: 15px;
+  color: var(--ink);
+  text-align: left;
+  margin: 26px 4px 12px;
+}
+
 .chart-container {
   position: relative;
   height: 260px;

--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -364,6 +364,7 @@ body {
 }
 
 #analyze {
+  margin-top: 34px;
   margin-bottom: 8px;
   display: flex;
   flex-wrap: wrap;

--- a/src/controllers/chartController.ts
+++ b/src/controllers/chartController.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express"
-import { fetchChartModel, fetchYearlyChartModel, fetchCostByCategoryModel } from "../models/chartModel";
+import { fetchChartModel, fetchYearlyChartModel, fetchMonthlyChartModel, fetchCostByCategoryModel } from "../models/chartModel";
 import { getCostCategoryLabel } from "../config/costCategories";
 
 //集計・分析ページを描画し、プルダウンの初期選択用に現在の年月を渡す
@@ -52,5 +52,19 @@ export const fetchYearlyChartController = async (req: Request, res: Response) =>
     } catch (error) {
         console.error("年間集計の取得に失敗しました", error);
         res.status(500).json({ message: "年間集計の取得に失敗しました" });
+    }
+}
+
+//選択年の月ごと集計（活動回数・費用）を1〜12月ぶんJSONで返す。年のみ依存のため月別円グラフとは分離
+export const fetchMonthlyChartController = async (req: Request, res: Response) => {
+    try {
+        const year = req.query.year as string;
+        // 未指定/不正な年はMySQLのバインドエラー（例外→500）を招くため、Model呼び出し前に弾く
+        if (!/^\d{4}$/.test(year)) return res.status(400).json({ message: "年の指定が正しくありません" });
+        const months = await fetchMonthlyChartModel(year);
+        res.status(200).json({ months });
+    } catch (error) {
+        console.error("月別集計の取得に失敗しました", error);
+        res.status(500).json({ message: "月別集計の取得に失敗しました" });
     }
 }

--- a/src/models/chartModel.ts
+++ b/src/models/chartModel.ts
@@ -46,8 +46,11 @@ type monthlyChart={
 //指定年の月ごと活動回数・費用を1〜12月ぶん返す。無い月はcount:0/cost:0で0埋め
 export const fetchMonthlyChartModel=async(year:string):Promise<monthlyChart[]>=>{
     // 回数は memories、費用は memory_costs.amount 由来へ切替（JOINによる回数の水増しを避けるため別クエリ）
-    const [countRows]=await connection.execute('select MONTH(date) as month, COUNT(*) as count from memories where YEAR(date)=? AND date <= CURDATE() group by MONTH(date)',[year])
-    const [costRows]=await connection.execute('select MONTH(m.date) as month, sum(mc.amount) as cost from memory_costs mc join memories m on mc.memory_id = m.id where YEAR(m.date)=? AND m.date <= CURDATE() group by MONTH(m.date)',[year])
+    // 2クエリは独立しているため Promise.all で並列発行してレイテンシを抑える
+    const [[countRows],[costRows]]=await Promise.all([
+        connection.execute('select MONTH(date) as month, COUNT(*) as count from memories where YEAR(date)=? AND date <= CURDATE() group by MONTH(date)',[year]),
+        connection.execute('select MONTH(m.date) as month, sum(mc.amount) as cost from memory_costs mc join memories m on mc.memory_id = m.id where YEAR(m.date)=? AND m.date <= CURDATE() group by MONTH(m.date)',[year])
+    ])
     const counts=countRows as { month:number, count:number }[];
     const costs=costRows as { month:number, cost:string }[];
     const countMap=new Map<number, number>();

--- a/src/models/chartModel.ts
+++ b/src/models/chartModel.ts
@@ -36,6 +36,37 @@ export const fetchYearlyChartModel=async(year:string):Promise<yearlySummary[]>=>
     return [{ count, cost }];
 }
 
+//月別棒グラフ用の型（1〜12月ぶんを0埋めして返す）
+type monthlyChart={
+    month:number,
+    count:number,
+    cost:number
+}
+
+//指定年の月ごと活動回数・費用を1〜12月ぶん返す。無い月はcount:0/cost:0で0埋め
+export const fetchMonthlyChartModel=async(year:string):Promise<monthlyChart[]>=>{
+    // 回数は memories、費用は memory_costs.amount 由来へ切替（JOINによる回数の水増しを避けるため別クエリ）
+    const [countRows]=await connection.execute('select MONTH(date) as month, COUNT(*) as count from memories where YEAR(date)=? AND date <= CURDATE() group by MONTH(date)',[year])
+    const [costRows]=await connection.execute('select MONTH(m.date) as month, sum(mc.amount) as cost from memory_costs mc join memories m on mc.memory_id = m.id where YEAR(m.date)=? AND m.date <= CURDATE() group by MONTH(m.date)',[year])
+    const counts=countRows as { month:number, count:number }[];
+    const costs=costRows as { month:number, cost:string }[];
+    const countMap=new Map<number, number>();
+    for(const c of counts){
+        countMap.set(c.month, c.count);
+    }
+    const costMap=new Map<number, string>();
+    for(const c of costs){
+        costMap.set(c.month, c.cost);
+    }
+    // SQLは活動のある月しか返さないため、1〜12月をループして無い月は0埋めする
+    const result:monthlyChart[]=[];
+    for(let m=1;m<=12;m++){
+        // SUM(amount)はmysql2から文字列で返るためNum()で数値化する
+        result.push({ month: m, count: countMap.get(m) ?? 0, cost: Number(costMap.get(m) ?? 0) });
+    }
+    return result;
+}
+
 //費用カテゴリ別ランキング用の型
 type costByCategory={
     category:string,

--- a/src/routes/chartRoute.ts
+++ b/src/routes/chartRoute.ts
@@ -1,9 +1,10 @@
 import express from 'express';
-import { fetchChartController, fetchYearlyChartController } from '../controllers/chartController';
+import { fetchChartController, fetchYearlyChartController, fetchMonthlyChartController } from '../controllers/chartController';
 
 const router=express.Router();
 
 router.get('/',fetchChartController);
 router.get('/yearly',fetchYearlyChartController);
+router.get('/monthly',fetchMonthlyChartController);
 
 export default router

--- a/src/views/chart.ejs
+++ b/src/views/chart.ejs
@@ -235,15 +235,17 @@
     return `${value}`;
   }
 
-  // 軸の刻み幅を「きりの良い値」で決める。目盛りが増えすぎないよう、データ上限に応じて
-  // unit×(1→2→5→10→20…) と刻みを広げる（目盛り数はおよそ8以内）。回数は unit=1、費用は unit=10000
-  const niceStep = (maxVal, unit) => {
-    const candidates = [1, 2, 5, 10, 20, 50, 100, 200, 500];
-    const maxU = maxVal / unit;
-    for (const c of candidates) {
-      if (maxU / c <= 8) return c * unit;
+  // 軸の刻み幅を「きりの良い値」(1/2/5×10ⁿ)で決める。目盛りが6本前後になるようデータ上限から算出し、
+  // データが小さい年でも棒がつぶれないよう最小刻み minStep を下限にする（回数=1回、費用=1000円）
+  const niceStep = (maxVal, minStep) => {
+    if (maxVal <= 0) return minStep;
+    const rough = maxVal / 6;
+    const pow = Math.pow(10, Math.floor(Math.log10(rough)));
+    for (const c of [1, 2, 5, 10]) {
+      const step = c * pow;
+      if (step >= rough) return Math.max(step, minStep);
     }
-    return candidates[candidates.length - 1] * unit;
+    return Math.max(10 * pow, minStep);
   }
 
   // 月別の棒グラフ（活動回数・費用）。年のみ依存のため月別円グラフとは別に取得する
@@ -278,10 +280,11 @@
       }
       wrap.hidden = false;
 
-      // 回数・費用とも、きりの良い刻みで上限をデータに合わせて自動で伸ばす（回数は1刻みから、費用は1万刻みから）
+      // 回数・費用とも、きりの良い刻みで上限をデータに合わせて自動で伸ばす。
+      // 最小刻みは回数=1回・費用=1000円まで下げ、少額の月ばかりの年でも棒が見えるようにする
       const countStep = niceStep(Math.max(...counts), 1);
       const countMax = Math.max(countStep, Math.ceil(Math.max(...counts) / countStep) * countStep);
-      const costStep = niceStep(Math.max(...costs), 10000);
+      const costStep = niceStep(Math.max(...costs), 1000);
       const costMax = Math.max(costStep, Math.ceil(Math.max(...costs) / costStep) * costStep);
 
       const ctxCount = document.getElementById('myMonthlyCountChart').getContext('2d');

--- a/src/views/chart.ejs
+++ b/src/views/chart.ejs
@@ -49,7 +49,7 @@
     <span class="zone-ic coral">🔍</span>
     <div class="zone-head-text">
       <div class="zone-title">月別のくわしい内訳</div>
-      <div class="zone-sub">月を選ぶと、選択中の年のその月の円グラフとランキングが切り替わります</div>
+      <div class="zone-sub">月を選ぶと、上記選択中の年のその月の円グラフとランキングが切り替わります</div>
     </div>
   </div>
   <div class="zone-select">

--- a/src/views/chart.ejs
+++ b/src/views/chart.ejs
@@ -257,6 +257,8 @@
     try {
       const response = await fetch(`/api/chart/monthly?year=${selectedYear}`)
       const data = await response.json();
+      // 年を素早く切り替えたとき、古い応答が新しい選択を上書きしないよう破棄する
+      if (year.value !== String(selectedYear)) return;
       if (myMonthlyCountChart) {
         myMonthlyCountChart.destroy();
         myMonthlyCountChart = null;

--- a/src/views/chart.ejs
+++ b/src/views/chart.ejs
@@ -42,6 +42,7 @@
       <canvas id="myMonthlyCostChart"></canvas>
     </div>
   </div>
+  <p id="monthly-message"></p>
 </div>
 
 <div class="zone month">
@@ -251,6 +252,7 @@
   // 月別の棒グラフ（活動回数・費用）。年のみ依存のため月別円グラフとは別に取得する
   const loadMonthly = async (selectedYear) => {
     const wrap = document.getElementById('monthly-summary');
+    const message = document.getElementById('monthly-message');
     const labels = ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月'];
     const legendFont = { family: "'Zen Maru Gothic', sans-serif" };
     const tickFont = { family: "'Zen Maru Gothic', sans-serif" };
@@ -269,18 +271,21 @@
       }
       if (!response.ok) {
         wrap.hidden = true;
+        message.textContent = '月別データの取得に失敗しました';
         return;
       }
       const months = data.months || [];
       const counts = months.map((m) => m.count || 0);
       const costs = months.map((m) => m.cost || 0);
       const totalCount = counts.reduce((a, b) => a + b, 0);
-      // データ0件の年は月別セクションごと非表示
+      // データ0件の年は月別セクションごと非表示（エラーではないのでメッセージは出さない）
       if (totalCount === 0) {
         wrap.hidden = true;
+        message.textContent = '';
         return;
       }
       wrap.hidden = false;
+      message.textContent = '';
 
       // 回数・費用とも、きりの良い刻みで上限をデータに合わせて自動で伸ばす。
       // 最小刻みは回数=1回・費用=1000円まで下げ、少額の月ばかりの年でも棒が見えるようにする
@@ -344,6 +349,8 @@
     } catch (error) {
       console.error(error);
       wrap.hidden = true;
+      // 通信・サーバエラー時は「0件の年」と区別できるよう日本語メッセージを出す
+      message.textContent = '月別データの取得に失敗しました';
     }
   }
 

--- a/src/views/chart.ejs
+++ b/src/views/chart.ejs
@@ -15,6 +15,17 @@
   </div>
 </div>
 
+<div id="monthly-summary" hidden>
+  <div class="monthly-heading" id="monthly-count-heading">月ごとの活動回数</div>
+  <div class="chart-container">
+    <canvas id="myMonthlyCountChart"></canvas>
+  </div>
+  <div class="monthly-heading" id="monthly-cost-heading">月ごとの費用</div>
+  <div class="chart-container">
+    <canvas id="myMonthlyCostChart"></canvas>
+  </div>
+</div>
+
 <div id="analyze">
   <label for="month">年・月を選択してください</label>
   <div>
@@ -63,6 +74,8 @@
   const month = document.getElementById('month')
   let myChart = null;
   let myCostChart = null;
+  let myMonthlyCountChart = null;
+  let myMonthlyCostChart = null;
 
   const loadChart = async (selectedYear, selectedMonth) => {
     const message = document.getElementById('chart-message');
@@ -190,18 +203,126 @@
     }
   }
 
+  // 費用軸の省略表記：1万以上は「○万」（割り切れなければ小数1桁）、1000〜9999は「○千」、それ未満はそのまま
+  const formatCostAxis = (value) => {
+    if (value >= 10000) {
+      const man = value / 10000;
+      // 末尾の0を省く（8.0万→8万、12.5万→12.5万）
+      return `${Number(man.toFixed(1))}万`;
+    }
+    if (value >= 1000) {
+      const sen = value / 1000;
+      return `${Number(sen.toFixed(1))}千`;
+    }
+    return `${value}`;
+  }
+
+  // 月別の棒グラフ（活動回数・費用）。年のみ依存のため月別円グラフとは別に取得する
+  const loadMonthly = async (selectedYear) => {
+    const wrap = document.getElementById('monthly-summary');
+    const labels = ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月'];
+    const legendFont = { family: "'Zen Maru Gothic', sans-serif" };
+    const tickFont = { family: "'Zen Maru Gothic', sans-serif" };
+    try {
+      const response = await fetch(`/api/chart/monthly?year=${selectedYear}`)
+      const data = await response.json();
+      if (myMonthlyCountChart) {
+        myMonthlyCountChart.destroy();
+        myMonthlyCountChart = null;
+      }
+      if (myMonthlyCostChart) {
+        myMonthlyCostChart.destroy();
+        myMonthlyCostChart = null;
+      }
+      if (!response.ok) {
+        wrap.hidden = true;
+        return;
+      }
+      const months = data.months || [];
+      const counts = months.map((m) => m.count || 0);
+      const costs = months.map((m) => m.cost || 0);
+      const totalCount = counts.reduce((a, b) => a + b, 0);
+      // データ0件の年は月別セクションごと非表示
+      if (totalCount === 0) {
+        wrap.hidden = true;
+        return;
+      }
+      wrap.hidden = false;
+
+      const ctxCount = document.getElementById('myMonthlyCountChart').getContext('2d');
+      const ctxCost = document.getElementById('myMonthlyCostChart').getContext('2d');
+      myMonthlyCountChart = new Chart(ctxCount, {
+        type: 'bar',
+        data: {
+          labels: labels,
+          datasets: [{
+            label: '活動回数',
+            data: counts,
+            backgroundColor: '#E3A08D',
+            borderRadius: 4
+          }]
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: {
+            legend: { position: 'bottom', labels: { font: legendFont, color: '#5A5248', padding: 14, boxWidth: 12, usePointStyle: true } },
+            datalabels: { display: false },
+            tooltip: { callbacks: { label: (ctx) => `${ctx.parsed.y}回` } }
+          },
+          scales: {
+            x: { ticks: { font: tickFont, color: '#5A5248' } },
+            y: { beginAtZero: true, ticks: { font: tickFont, color: '#5A5248', precision: 0 } }
+          }
+        }
+      });
+      myMonthlyCostChart = new Chart(ctxCost, {
+        type: 'bar',
+        data: {
+          labels: labels,
+          datasets: [{
+            label: '費用(円)',
+            data: costs,
+            backgroundColor: '#A9C2A0',
+            borderRadius: 4
+          }]
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: {
+            legend: { position: 'bottom', labels: { font: legendFont, color: '#5A5248', padding: 14, boxWidth: 12, usePointStyle: true } },
+            datalabels: { display: false },
+            tooltip: { callbacks: { label: (ctx) => `${(ctx.parsed.y || 0).toLocaleString()}円` } }
+          },
+          scales: {
+            x: { ticks: { font: tickFont, color: '#5A5248' } },
+            y: { beginAtZero: true, ticks: { font: tickFont, color: '#5A5248', callback: (value) => formatCostAxis(value) } }
+          }
+        }
+      });
+    } catch (error) {
+      console.error(error);
+      wrap.hidden = true;
+    }
+  }
+
   // 年・月どちらを変更しても再取得する
   const handleChange = () => {
     loadChart(year.value, month.value);
   }
   year.addEventListener('change', handleChange)
   month.addEventListener('change', handleChange)
-  // 年間サマリーは年の変更時のみ更新（月には依存しない）
-  year.addEventListener('change', () => loadYearly(year.value))
+  // 年間サマリー・月別棒グラフは年の変更時のみ更新（月には依存しない）
+  year.addEventListener('change', () => {
+    loadYearly(year.value);
+    loadMonthly(year.value);
+  })
 
   // 初期表示：サーバーで選択済みの今年・今月で自動取得する
   window.addEventListener('DOMContentLoaded', () => {
     loadChart(year.value, month.value);
     loadYearly(year.value);
+    loadMonthly(year.value);
   })
 </script>

--- a/src/views/chart.ejs
+++ b/src/views/chart.ejs
@@ -217,6 +217,17 @@
     return `${value}`;
   }
 
+  // 軸の刻み幅を「きりの良い値」で決める。目盛りが増えすぎないよう、データ上限に応じて
+  // unit×(1→2→5→10→20…) と刻みを広げる（目盛り数はおよそ8以内）。回数は unit=1、費用は unit=10000
+  const niceStep = (maxVal, unit) => {
+    const candidates = [1, 2, 5, 10, 20, 50, 100, 200, 500];
+    const maxU = maxVal / unit;
+    for (const c of candidates) {
+      if (maxU / c <= 8) return c * unit;
+    }
+    return candidates[candidates.length - 1] * unit;
+  }
+
   // 月別の棒グラフ（活動回数・費用）。年のみ依存のため月別円グラフとは別に取得する
   const loadMonthly = async (selectedYear) => {
     const wrap = document.getElementById('monthly-summary');
@@ -249,6 +260,12 @@
       }
       wrap.hidden = false;
 
+      // 回数・費用とも、きりの良い刻みで上限をデータに合わせて自動で伸ばす（回数は1刻みから、費用は1万刻みから）
+      const countStep = niceStep(Math.max(...counts), 1);
+      const countMax = Math.max(countStep, Math.ceil(Math.max(...counts) / countStep) * countStep);
+      const costStep = niceStep(Math.max(...costs), 10000);
+      const costMax = Math.max(costStep, Math.ceil(Math.max(...costs) / costStep) * costStep);
+
       const ctxCount = document.getElementById('myMonthlyCountChart').getContext('2d');
       const ctxCost = document.getElementById('myMonthlyCostChart').getContext('2d');
       myMonthlyCountChart = new Chart(ctxCount, {
@@ -272,7 +289,7 @@
           },
           scales: {
             x: { ticks: { font: tickFont, color: '#5A5248' } },
-            y: { beginAtZero: true, ticks: { font: tickFont, color: '#5A5248', precision: 0 } }
+            y: { beginAtZero: true, max: countMax, ticks: { font: tickFont, color: '#5A5248', stepSize: countStep, precision: 0 } }
           }
         }
       });
@@ -297,7 +314,7 @@
           },
           scales: {
             x: { ticks: { font: tickFont, color: '#5A5248' } },
-            y: { beginAtZero: true, ticks: { font: tickFont, color: '#5A5248', callback: (value) => formatCostAxis(value) } }
+            y: { beginAtZero: true, max: costMax, ticks: { font: tickFont, color: '#5A5248', stepSize: costStep, callback: (value) => formatCostAxis(value) } }
           }
         }
       });

--- a/src/views/chart.ejs
+++ b/src/views/chart.ejs
@@ -1,41 +1,59 @@
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2"></script>
 
-<div id="yearly-summary">
-  <div id="yearly-heading"></div>
-  <div class="summary-cards">
-    <div class="summary-card">
-      <div class="summary-card-title">活動回数</div>
-      <div class="summary-card-value" id="yearly-count">0回</div>
-    </div>
-    <div class="summary-card">
-      <div class="summary-card-title">合計費用</div>
-      <div class="summary-card-value" id="yearly-cost">0円</div>
+<div class="zone year">
+  <div class="zone-head">
+    <span class="zone-ic blue">📅</span>
+    <div class="zone-head-text">
+      <div class="zone-title">年間の記録</div>
+      <div class="zone-sub">年を選ぶと、この下の年間サマリーと月別グラフが切り替わります</div>
     </div>
   </div>
-</div>
-
-<div id="monthly-summary" hidden>
-  <div class="monthly-heading" id="monthly-count-heading">月ごとの活動回数</div>
-  <div class="chart-container">
-    <canvas id="myMonthlyCountChart"></canvas>
-  </div>
-  <div class="monthly-heading" id="monthly-cost-heading">月ごとの費用</div>
-  <div class="chart-container">
-    <canvas id="myMonthlyCostChart"></canvas>
-  </div>
-</div>
-
-<div id="analyze">
-  <label for="month">年・月を選択してください</label>
-  <div>
+  <div class="zone-select">
+    <label for="year">年</label>
     <select id="year">
       <% for (let y = Math.min(2025, currentYear); y <= currentYear; y++) { %>
       <option value="<%= y %>" <%= currentYear === y ? 'selected' : '' %>><%= y %>年</option>
       <% } %>
     </select>
   </div>
-  <div>
+
+  <div id="yearly-summary">
+    <div id="yearly-heading"></div>
+    <div class="summary-cards">
+      <div class="summary-card">
+        <div class="summary-card-title">活動回数</div>
+        <div class="summary-card-value" id="yearly-count">0回</div>
+      </div>
+      <div class="summary-card">
+        <div class="summary-card-title">合計費用</div>
+        <div class="summary-card-value" id="yearly-cost">0円</div>
+      </div>
+    </div>
+  </div>
+
+  <div id="monthly-summary" hidden>
+    <div class="monthly-heading" id="monthly-count-heading">月ごとの活動回数</div>
+    <div class="chart-container">
+      <canvas id="myMonthlyCountChart"></canvas>
+    </div>
+    <div class="monthly-heading" id="monthly-cost-heading">月ごとの費用</div>
+    <div class="chart-container">
+      <canvas id="myMonthlyCostChart"></canvas>
+    </div>
+  </div>
+</div>
+
+<div class="zone month">
+  <div class="zone-head">
+    <span class="zone-ic coral">🔍</span>
+    <div class="zone-head-text">
+      <div class="zone-title">月別のくわしい内訳</div>
+      <div class="zone-sub">月を選ぶと、選択中の年のその月の円グラフとランキングが切り替わります</div>
+    </div>
+  </div>
+  <div class="zone-select">
+    <label for="month">月</label>
     <select id="month">
       <option value="1" <%= currentMonth === 1 ? 'selected' : '' %>>1月</option>
       <option value="2" <%= currentMonth === 2 ? 'selected' : '' %>>2月</option>
@@ -51,21 +69,21 @@
       <option value="12" <%= currentMonth === 12 ? 'selected' : '' %>>12月</option>
     </select>
   </div>
-</div>
 
-<div id="chart-message"></div>
+  <div id="chart-message"></div>
 
-<div id="chart-results" hidden>
-  <div id="oshikatu-percent"></div>
-  <div class="chart-container">
-    <canvas id="myPieChart"></canvas>
+  <div id="chart-results" hidden>
+    <div id="oshikatu-percent"></div>
+    <div class="chart-container">
+      <canvas id="myPieChart"></canvas>
+    </div>
+    <div id="oshikatu-cost"></div>
+    <div class="chart-container">
+      <canvas id="myCostPieChart"></canvas>
+    </div>
+    <div id="cost-ranking-heading">カテゴリ別支出ランキング</div>
+    <ul id="cost-ranking"></ul>
   </div>
-  <div id="oshikatu-cost"></div>
-  <div class="chart-container">
-    <canvas id="myCostPieChart"></canvas>
-  </div>
-  <div id="cost-ranking-heading">カテゴリ別支出ランキング</div>
-  <ul id="cost-ranking"></ul>
 </div>
 
 <script>


### PR DESCRIPTION
## 概要
集計画面の年間サマリーの下に、選択中の年の1〜12月それぞれの「活動回数」と「費用」を棒グラフ2つ（案A）で表示する。「今年どの月に活発だったか／お金を使ったか」を一目で把握できるようにする。

## 主な変更
- **新エンドポイント `GET /api/chart/monthly?year=`**（route/controller/model を追加）
  - 回数＝`memories` 件数の月別集計（全カテゴリ合算）、費用＝`memory_costs.amount` 合計の月別集計
  - 回数と費用は**別クエリで集計しJSで月紐付け**（JOINによる回数の水増しを回避、既存 `fetchYearlyChartModel` と同じ方針）。`date <= CURDATE()` 基準。必ず1〜12月の12件を返し、活動の無い月は0埋め。cost は `Number()` で数値化
  - year は `/^\d{4}$/` で検証し、不正時は 400＋日本語メッセージ
- **クライアント（chart.ejs）**：年間サマリー直下に月別セクション（初期hidden）を追加。`loadMonthly()` で Chart.js の bar チャート2つを描画（回数＝コーラル#E3A08D、費用＝セージ#A9C2A0）
  - 年セレクト変更・DOMContentLoaded で更新（**月変更では非連動**）。再取得時に `destroy()` して再生成（canvas再利用エラー回避）
  - 費用Y軸は「万/千」省略表記、回数Y軸は整数(precision:0)、月ラベル1〜12、ツールチップは正確値、棒の数値ラベルは `datalabels:{display:false}` で非表示
  - **12ヶ月の回数合計が0の年は月別セクションを非表示**
- 既存の月別円グラフ・年間サマリー・カテゴリ別ランキングは不変

## 対象外
月別のカテゴリ別内訳（合計のみ）／複合グラフ・折れ線（案B/Cは不採用）／棒の数値ラベル。

## 確認方法
1. `npm run dev` → 集計画面を開く
2. 年間サマリーの下に、選択年の月ごとの活動回数・費用の棒グラフ2つが表示される
3. 年セレクトを変えると年間サマリーと月別グラフが更新される。月セレクトでは月別円グラフのみ変化（月別棒グラフは変わらない）
4. データのある年で表示、活動が無い年は月別セクションが非表示になる
5. `npm run build` 成功済み

## 設計メモ
- 回数と費用を別クエリにするのは、`memories LEFT JOIN memory_costs` だと費用行数分だけ回数が水増しされるため（既存集計と同じ回避策。集計軸が category → MONTH(date) に変わるだけ）
- 0埋めはアプリ側（1〜12月ループ＋Map）で行い、Viewは常に12件前提で描画できるようにした

🤖 Generated with [Claude Code](https://claude.com/claude-code)